### PR TITLE
Launch MAJH Studio Pro and improve tournament registration flow

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -36,7 +36,7 @@ export default async function DashboardOverviewPage() {
         )
       `)
       .eq("player_id", user.id)
-      .in("status", ["registered", "checked_in", "pending_payment"])
+      .in("status", ["registered", "checked_in", "pending"])
       .order("created_at", { ascending: false })
       .limit(5)
   ])

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -36,7 +36,7 @@ export default async function DashboardOverviewPage() {
         )
       `)
       .eq("player_id", user.id)
-      .in("status", ["registered", "checked_in", "pending"])
+      .in("status", ["registered", "checked_in"])
       .order("created_at", { ascending: false })
       .limit(5)
   ])

--- a/lib/esports-actions.ts
+++ b/lib/esports-actions.ts
@@ -257,7 +257,7 @@ export async function registerForTournament(tournamentId: string) {
     .from("tournament_registrations")
     .select("*", { count: "exact", head: true })
     .eq("tournament_id", tournamentId)
-    .in("status", ["registered", "checked_in", "pending"])
+    .in("status", ["registered", "checked_in"])
 
   if (tournament.max_participants && (count ?? 0) >= tournament.max_participants) {
     return { error: "Tournament is full" }
@@ -272,7 +272,7 @@ export async function registerForTournament(tournamentId: string) {
         player_id: user.id,
         registration_type: "paid",
         payment_status: "pending",
-        status: "pending",
+status: "registered",
       })
       .select()
       .single()

--- a/lib/esports-actions.ts
+++ b/lib/esports-actions.ts
@@ -257,7 +257,7 @@ export async function registerForTournament(tournamentId: string) {
     .from("tournament_registrations")
     .select("*", { count: "exact", head: true })
     .eq("tournament_id", tournamentId)
-    .in("status", ["registered", "checked_in", "pending_payment"])
+    .in("status", ["registered", "checked_in", "pending"])
 
   if (tournament.max_participants && (count ?? 0) >= tournament.max_participants) {
     return { error: "Tournament is full" }
@@ -272,7 +272,7 @@ export async function registerForTournament(tournamentId: string) {
         player_id: user.id,
         registration_type: "paid",
         payment_status: "pending",
-        status: "pending_payment",
+        status: "pending",
       })
       .select()
       .single()


### PR DESCRIPTION
- Launched the MAJH Studio Pro streaming hub and updated the tournament dashboard.
- Standardized registration status values by replacing 'pending_payment' with 'pending' for valid entries.
- Updated paid tournament logic to correctly handle and allow 'registered' status during the pending payment phase.

[v0 Session](https://v0.app/chat/dzJmMNOSQEs)