### PR TITLE
Launch MAJH Studio Pro and enable wallet-based tournament registration

### DIFF
--- a/app/dashboard/admin/financials/page.tsx
+++ b/app/dashboard/admin/financials/page.tsx
@@ -41,6 +41,7 @@ export default async function AdminFinancialsPage() {
   const [
     { data: deposits },
     { data: entryFees },
+    { data: platformFees },
     { data: pendingWithdrawals },
     { data: activeEscrows },
     { data: recentTransactions },
@@ -52,11 +53,18 @@ export default async function AdminFinancialsPage() {
       .eq("type", "deposit")
       .eq("status", "completed")
       .gte("created_at", monthStart),
-    // Total entry fees this month (platform revenue)
+    // Total entry fees this month
     supabase
       .from("financial_transactions")
       .select("amount_cents")
       .eq("type", "entry_fee")
+      .eq("status", "completed")
+      .gte("created_at", monthStart),
+    // Platform fees (actual revenue)
+    supabase
+      .from("financial_transactions")
+      .select("amount_cents")
+      .eq("type", "platform_fee")
       .eq("status", "completed")
       .gte("created_at", monthStart),
     // Pending withdrawals
@@ -91,8 +99,10 @@ export default async function AdminFinancialsPage() {
   const pendingWithdrawalsAmount = pendingWithdrawals?.reduce((sum, w) => sum + Math.abs(w.amount_cents || 0), 0) || 0
   const activeEscrowsAmount = activeEscrows?.reduce((sum, e) => sum + (e.funded_amount_cents || 0), 0) || 0
   
-  // Platform fee is 5% of entry fees
-  const platformFeesAmount = Math.round(totalEntryFeesAmount * 0.05)
+  // Platform fees - actual recorded revenue from tournament payouts
+  // Falls back to 5% estimate if no platform_fee transactions recorded yet
+  const recordedPlatformFees = platformFees?.reduce((sum, f) => sum + (f.amount_cents || 0), 0) || 0
+  const platformFeesAmount = recordedPlatformFees > 0 ? recordedPlatformFees : Math.round(totalEntryFeesAmount * 0.05)
 
   const formatCurrency = (cents: number) => {
     return new Intl.NumberFormat("en-US", {

--- a/components/financials/admin-wallet-credit.tsx
+++ b/components/financials/admin-wallet-credit.tsx
@@ -8,20 +8,32 @@ import { Textarea } from "@/components/ui/textarea"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Loader2, CreditCard, CheckCircle, AlertTriangle } from "lucide-react"
-import { adminCreditWallet } from "@/lib/wallet-actions"
+import { adminCreditWallet, syncWalletBalance } from "@/lib/wallet-actions"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { RefreshCw } from "lucide-react"
 
 export function AdminWalletCredit() {
   const [userId, setUserId] = useState("")
+  const [syncUserId, setSyncUserId] = useState("")
   const [amountDollars, setAmountDollars] = useState("")
   const [description, setDescription] = useState("")
   const [stripeSessionId, setStripeSessionId] = useState("")
   const [loading, setLoading] = useState(false)
+  const [syncLoading, setSyncLoading] = useState(false)
   const [result, setResult] = useState<{
     success?: boolean
     error?: string
     previousBalance?: number
     newBalance?: number
     credited?: number
+  } | null>(null)
+  const [syncResult, setSyncResult] = useState<{
+    success?: boolean
+    error?: string
+    previousBalance?: number
+    newBalance?: number
+    transactionCount?: number
+    adjustment?: number
   } | null>(null)
 
   async function handleSubmit(e: React.FormEvent) {
@@ -55,6 +67,26 @@ export function AdminWalletCredit() {
     }
   }
 
+  async function handleSync(e: React.FormEvent) {
+    e.preventDefault()
+    setSyncLoading(true)
+    setSyncResult(null)
+
+    if (!syncUserId.trim()) {
+      setSyncResult({ error: "Please enter a valid User ID" })
+      setSyncLoading(false)
+      return
+    }
+
+    const response = await syncWalletBalance(syncUserId)
+    setSyncResult(response)
+    setSyncLoading(false)
+
+    if (response.success) {
+      setSyncUserId("")
+    }
+  }
+
   const formatCurrency = (cents: number) => {
     return new Intl.NumberFormat("en-US", {
       style: "currency",
@@ -70,11 +102,98 @@ export function AdminWalletCredit() {
           Manual Wallet Credit
         </CardTitle>
         <CardDescription>
-          Manually credit a user&apos;s wallet (for failed webhook recovery or adjustments)
+          Sync wallet balance or manually credit a user&apos;s wallet
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <Tabs defaultValue="sync" className="w-full">
+          <TabsList className="grid w-full grid-cols-2 mb-4">
+            <TabsTrigger value="sync" className="flex items-center gap-2">
+              <RefreshCw className="h-4 w-4" />
+              Sync Balance
+            </TabsTrigger>
+            <TabsTrigger value="credit" className="flex items-center gap-2">
+              <CreditCard className="h-4 w-4" />
+              Manual Credit
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="sync">
+            <form onSubmit={handleSync} className="space-y-4">
+              <Alert>
+                <RefreshCw className="h-4 w-4" />
+                <AlertDescription>
+                  <strong>Recommended for failed webhooks:</strong> This recalculates the wallet balance 
+                  from existing transactions without creating a new entry. Use this when a payment was 
+                  recorded but the wallet balance wasn&apos;t updated.
+                </AlertDescription>
+              </Alert>
+
+              <div className="space-y-2">
+                <Label htmlFor="syncUserId">User ID</Label>
+                <Input
+                  id="syncUserId"
+                  placeholder="UUID of the user"
+                  value={syncUserId}
+                  onChange={(e) => setSyncUserId(e.target.value)}
+                  required
+                />
+              </div>
+
+              {syncResult && (
+                <Alert variant={syncResult.success ? "default" : "destructive"}>
+                  {syncResult.success ? (
+                    <CheckCircle className="h-4 w-4" />
+                  ) : (
+                    <AlertTriangle className="h-4 w-4" />
+                  )}
+                  <AlertDescription>
+                    {syncResult.success ? (
+                      <div className="space-y-1">
+                        <p>Wallet synced successfully!</p>
+                        <p className="text-sm">
+                          Previous: {formatCurrency(syncResult.previousBalance || 0)} → 
+                          New: {formatCurrency(syncResult.newBalance || 0)}
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          Based on {syncResult.transactionCount} transactions 
+                          (adjustment: {syncResult.adjustment && syncResult.adjustment >= 0 ? "+" : ""}
+                          {formatCurrency(syncResult.adjustment || 0)})
+                        </p>
+                      </div>
+                    ) : (
+                      syncResult.error
+                    )}
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              <Button type="submit" disabled={syncLoading} className="w-full sm:w-auto">
+                {syncLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Syncing...
+                  </>
+                ) : (
+                  <>
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                    Sync Wallet Balance
+                  </>
+                )}
+              </Button>
+            </form>
+          </TabsContent>
+
+          <TabsContent value="credit">
+            <Alert variant="destructive" className="mb-4">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertDescription>
+                <strong>Warning:</strong> This creates a new deposit transaction. Only use this 
+                if the payment was NOT recorded at all. For failed webhooks where the transaction 
+                exists, use &quot;Sync Balance&quot; instead.
+              </AlertDescription>
+            </Alert>
+            <form onSubmit={handleSubmit} className="space-y-4">
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="userId">User ID</Label>
@@ -160,6 +279,8 @@ export function AdminWalletCredit() {
             )}
           </Button>
         </form>
+          </TabsContent>
+        </Tabs>
       </CardContent>
     </Card>
   )

--- a/lib/wallet-actions.ts
+++ b/lib/wallet-actions.ts
@@ -460,3 +460,90 @@ export async function adminCreditWallet(
     credited: amountCents
   }
 }
+
+/**
+ * Sync wallet balance from transactions (no new entry created)
+ * Used when transactions exist but wallet balance is out of sync
+ * This recalculates the balance from all completed transactions
+ */
+export async function syncWalletBalance(targetUserId: string) {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  
+  if (!user) {
+    return { error: "You must be signed in" }
+  }
+
+  // Check if user is admin
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("is_admin")
+    .eq("id", user.id)
+    .single()
+
+  if (!profile?.is_admin) {
+    return { error: "Unauthorized - admin access required" }
+  }
+
+  // Get all completed transactions for this user
+  const { data: transactions, error: txError } = await supabase
+    .from("financial_transactions")
+    .select("amount_cents, type")
+    .eq("user_id", targetUserId)
+    .eq("status", "completed")
+
+  if (txError) {
+    return { error: `Failed to fetch transactions: ${txError.message}` }
+  }
+
+  // Calculate correct balance from transactions
+  // Deposits and prizes are positive, entry_fee and withdrawal are negative (stored as negative)
+  const calculatedBalance = transactions?.reduce((sum, tx) => {
+    return sum + (tx.amount_cents || 0)
+  }, 0) || 0
+
+  // Get current wallet
+  let { data: wallet } = await supabase
+    .from("wallets")
+    .select("*")
+    .eq("user_id", targetUserId)
+    .single()
+
+  const previousBalance = wallet?.balance_cents || 0
+
+  if (!wallet) {
+    // Create wallet with calculated balance
+    const { error: createError } = await supabase
+      .from("wallets")
+      .insert({ user_id: targetUserId, balance_cents: calculatedBalance })
+    
+    if (createError) {
+      return { error: `Failed to create wallet: ${createError.message}` }
+    }
+  } else {
+    // Update wallet to calculated balance
+    const { error: updateError } = await supabase
+      .from("wallets")
+      .update({ 
+        balance_cents: calculatedBalance,
+        updated_at: new Date().toISOString()
+      })
+      .eq("user_id", targetUserId)
+
+    if (updateError) {
+      return { error: updateError.message }
+    }
+  }
+
+  revalidatePath("/dashboard")
+  revalidatePath("/dashboard/wallet")
+  revalidatePath("/admin")
+  
+  return { 
+    success: true, 
+    previousBalance,
+    newBalance: calculatedBalance,
+    transactionCount: transactions?.length || 0,
+    adjustment: calculatedBalance - previousBalance
+  }
+}


### PR DESCRIPTION
- Launched MAJH Studio Pro platform.
- Enabled tournament registration using wallet balances.
- Added a "Sync Wallet Balance" utility to reconcile balances from transaction history and prevent double-counting.
- Updated payout functions to explicitly track and record platform revenue fees.

[v0 Session](https://v0.app/chat/dzJmMNOSQEs)